### PR TITLE
Support of Cygwin environment

### DIFF
--- a/bin/cocos.py
+++ b/bin/cocos.py
@@ -593,7 +593,7 @@ def convert_rules(rules):
 
 
 def os_is_win32():
-    return sys.platform == 'win32'
+    return sys.platform == 'win32' or sys.platform == 'cygwin'
 
 
 def os_is_32bit_windows():


### PR DESCRIPTION
'cygwin' is windows-related kind of platform that should be treated by cocos console. When you try to use the console in cygwin, it usually says `There isn't any available platforms` which is not true.
Related discussion on stackoverflow: http://stackoverflow.com/questions/27594348/cocos2d-there-isnt-any-available-platforms-error